### PR TITLE
PV2-3633 Clawback updates

### DIFF
--- a/src/SFA.DAS.Payments.RequiredPayments.Application.UnitTests/SFA.DAS.Payments.RequiredPayments.Application.UnitTests.csproj
+++ b/src/SFA.DAS.Payments.RequiredPayments.Application.UnitTests/SFA.DAS.Payments.RequiredPayments.Application.UnitTests.csproj
@@ -20,9 +20,9 @@
     <PackageReference Include="SFA.DAS.Payments.Application" Version="2.0.6-prerelease-21" />
     <PackageReference Include="SFA.DAS.Payments.Core" Version="2.0.6-prerelease-21" />
     <PackageReference Include="SFA.DAS.Payments.DataLocks.Messages" Version="0.1.137-prerelease-46" />
-    <PackageReference Include="SFA.DAS.Payments.EarningEvents.Messages" Version="2.0.0-prerelease-17" />
-    <PackageReference Include="SFA.DAS.Payments.Messages.Common" Version="2.0.6-prerelease-21" />
-    <PackageReference Include="SFA.DAS.Payments.Model.Core" Version="2.0.6-prerelease-21" />
+    <PackageReference Include="SFA.DAS.Payments.EarningEvents.Messages" Version="0.1.130-prerelease-7" />
+    <PackageReference Include="SFA.DAS.Payments.Messages.Common" Version="2.0.6-prerelease-31" />
+    <PackageReference Include="SFA.DAS.Payments.Model.Core" Version="2.0.6-prerelease-31" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/SFA.DAS.Payments.RequiredPayments.Application/SFA.DAS.Payments.RequiredPayments.Application.csproj
+++ b/src/SFA.DAS.Payments.RequiredPayments.Application/SFA.DAS.Payments.RequiredPayments.Application.csproj
@@ -23,7 +23,7 @@
     <PackageReference Include="SFA.DAS.Payments.Application" Version="2.0.6-prerelease-21" />
     <PackageReference Include="SFA.DAS.Payments.Core" Version="2.0.6-prerelease-21" />
     <PackageReference Include="SFA.DAS.Payments.DataLocks.Messages" Version="0.1.137-prerelease-46" />
-    <PackageReference Include="SFA.DAS.Payments.EarningEvents.Messages" Version="2.0.0-prerelease-17" />
+    <PackageReference Include="SFA.DAS.Payments.EarningEvents.Messages" Version="0.1.130-prerelease-7" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/SFA.DAS.Payments.RequiredPayments.ClawbackRemovedLearnerService/SFA.DAS.Payments.RequiredPayments.ClawbackRemovedLearnerService.csproj
+++ b/src/SFA.DAS.Payments.RequiredPayments.ClawbackRemovedLearnerService/SFA.DAS.Payments.RequiredPayments.ClawbackRemovedLearnerService.csproj
@@ -21,6 +21,7 @@
     <PackageReference Include="Microsoft.ServiceFabric.Data.Interfaces" Version="7.0.1010" />
     <PackageReference Include="SFA.DAS.Payments.Application" Version="2.0.6-prerelease-21" />
     <PackageReference Include="SFA.DAS.Payments.Core" Version="2.0.6-prerelease-21" />
+    <PackageReference Include="SFA.DAS.Payments.EarningEvents.Messages" Version="0.1.130-prerelease-7" />
     <PackageReference Include="SFA.DAS.Payments.Monitoring.Jobs.Client" Version="0.2.0-prerelease-957" />
     <PackageReference Include="SFA.DAS.Payments.ServiceFabric.Core" Version="2.0.3-prerelease-5" />
   </ItemGroup>

--- a/src/SFA.DAS.Payments.RequiredPayments.RemovedLearnerService.Interfaces/IRemovedLearnerService.cs
+++ b/src/SFA.DAS.Payments.RequiredPayments.RemovedLearnerService.Interfaces/IRemovedLearnerService.cs
@@ -13,5 +13,8 @@ namespace SFA.DAS.Payments.RequiredPayments.RemovedLearnerService.Interfaces
     public interface IRemovedLearnerService : IActor
     {
         Task<IList<IdentifiedRemovedLearningAim>> HandleReceivedProviderEarningsEvent(short academicYear, byte collectionPeriod, DateTime ilrSubmissionDateTime, CancellationToken cancellationToken);
+
+        Task<IList<IdentifiedRemovedLearningAim>> HandleApprentiecshipIneligibleForFundingEarningEvent(short academicYear, byte collectionPeriod, DateTime ilrSubmissionDateTime, CancellationToken cancellationToken);
+
     }
 }

--- a/src/SFA.DAS.Payments.RequiredPayments.RemovedLearnerService/RemovedLearnerService.cs
+++ b/src/SFA.DAS.Payments.RequiredPayments.RemovedLearnerService/RemovedLearnerService.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using Microsoft.ServiceFabric.Actors;
 using Microsoft.ServiceFabric.Actors.Runtime;
 using SFA.DAS.Payments.RequiredPayments.Application;
+using SFA.DAS.Payments.RequiredPayments.Application.Repositories;
 using SFA.DAS.Payments.RequiredPayments.Messages.Events;
 using SFA.DAS.Payments.RequiredPayments.RemovedLearnerService.Interfaces;
 
@@ -15,6 +16,7 @@ namespace SFA.DAS.Payments.RequiredPayments.RemovedLearnerService
     {
         private readonly long ukprn;
         private readonly IRemovedLearnerAimIdentificationService removedLearnerAimIdentificationService;
+        private readonly IPaymentHistoryRepository paymentHistoryRepository;
 
         public RemovedLearnerService(ActorService actorService, ActorId actorId, IRemovedLearnerAimIdentificationService removedLearnerAimIdentificationService) : base(actorService, actorId)
         {
@@ -27,6 +29,11 @@ namespace SFA.DAS.Payments.RequiredPayments.RemovedLearnerService
         }
 
         public async Task<IList<IdentifiedRemovedLearningAim>> HandleReceivedProviderEarningsEvent(short academicYear, byte collectionPeriod, DateTime ilrSubmissionDateTime, CancellationToken cancellationToken)
+        {
+            return await removedLearnerAimIdentificationService.IdentifyRemovedLearnerAims(academicYear, collectionPeriod, ukprn, ilrSubmissionDateTime, cancellationToken).ConfigureAwait(false);
+        }
+
+        public async Task<IList<IdentifiedRemovedLearningAim>> HandleApprentiecshipIneligibleForFundingEarningEvent(short academicYear, byte collectionPeriod, DateTime ilrSubmissionDateTime, CancellationToken cancellationToken)
         {
             return await removedLearnerAimIdentificationService.IdentifyRemovedLearnerAims(academicYear, collectionPeriod, ukprn, ilrSubmissionDateTime, cancellationToken).ConfigureAwait(false);
         }

--- a/src/SFA.DAS.Payments.RequiredPayments.RequiredPaymentsProxyService/Handlers/ApprentiecshipIneligibleForFundingEarningEventHandler.cs
+++ b/src/SFA.DAS.Payments.RequiredPayments.RequiredPaymentsProxyService/Handlers/ApprentiecshipIneligibleForFundingEarningEventHandler.cs
@@ -1,0 +1,47 @@
+﻿using ESFA.DC.Logging.Interfaces;
+using Microsoft.ServiceFabric.Actors;
+using Microsoft.ServiceFabric.Actors.Client;
+using NServiceBus;
+using SFA.DAS.Payments.Application.Infrastructure.Logging;
+using SFA.DAS.Payments.EarningEvents.Messages.Events;
+using SFA.DAS.Payments.RequiredPayments.Domain;
+using SFA.DAS.Payments.RequiredPayments.Messages.Events;
+using SFA.DAS.Payments.RequiredPayments.RemovedLearnerService.Interfaces;
+using SFA.DAS.Payments.RequiredPayments.RequiredPaymentsService.Interfaces;
+using System;
+using System.Collections.ObjectModel;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace SFA.DAS.Payments.RequiredPayments.RequiredPaymentsProxyService.Handlers
+{
+    public class ApprentiecshipIneligibleForFundingEarningEventHandler : IHandleMessages<ApprenticeshipIneligibleForFundingEarningEvent>
+    {
+        private readonly IActorProxyFactory proxyFactory;
+        private readonly IPaymentLogger paymentLogger;
+
+        public ApprentiecshipIneligibleForFundingEarningEventHandler(IActorProxyFactory proxyFactory, IPaymentLogger paymentLogger)
+        {
+            this.proxyFactory = proxyFactory;
+            this.paymentLogger = paymentLogger;
+        }
+
+        public async Task Handle(ApprenticeshipIneligibleForFundingEarningEvent message, IMessageHandlerContext context)
+        {
+            paymentLogger.LogInfo($"Processing ApprentiecshipIneligibleForFundingEarningEvent, UKPRN: {message.Ukprn}, JobId: {message.JobId}, Period: {message.CollectionPeriod}, ILR: {message.IlrSubmissionDateTime}");
+
+            var actorId = new ActorId(message.Ukprn.ToString());
+            var actor = proxyFactory.CreateActorProxy<IRemovedLearnerService>(new Uri("fabric:/SFA.DAS.Payments.RequiredPayments.ServiceFabric/RemovedLearnerServiceActorService"), actorId);
+            var removedAims = await actor.HandleApprentiecshipIneligibleForFundingEarningEvent(message.CollectionPeriod.AcademicYear, message.CollectionPeriod.Period, message.IlrSubmissionDateTime, CancellationToken.None).ConfigureAwait(false);
+
+            foreach (var removedAim in removedAims)
+            {
+                removedAim.JobId = message.JobId;
+                await context.Publish(removedAim).ConfigureAwait(false);
+            }
+
+            paymentLogger.LogInfo($"Finished ApprentiecshipIneligibleForFundingEarningEvent, published {removedAims.Count} aims. UKPRN: {message.Ukprn}, JobId: {message.JobId}, Period: {message.CollectionPeriod}, ILR: {message.IlrSubmissionDateTime}");
+        }
+
+    }
+}

--- a/src/SFA.DAS.Payments.RequiredPayments.RequiredPaymentsProxyService/SFA.DAS.Payments.RequiredPayments.RequiredPaymentsProxyService.csproj
+++ b/src/SFA.DAS.Payments.RequiredPayments.RequiredPaymentsProxyService/SFA.DAS.Payments.RequiredPayments.RequiredPaymentsProxyService.csproj
@@ -19,7 +19,7 @@
     <PackageReference Include="SFA.DAS.Payments.Application" Version="2.0.6-prerelease-21" />
     <PackageReference Include="SFA.DAS.Payments.Core" Version="2.0.6-prerelease-21" />
     <PackageReference Include="SFA.DAS.Payments.DataLocks.Messages" Version="0.1.137-prerelease-46" />
-    <PackageReference Include="SFA.DAS.Payments.Messages.Common" Version="2.0.6-prerelease-21" />
+    <PackageReference Include="SFA.DAS.Payments.Messages.Common" Version="2.0.6-prerelease-31" />
     <PackageReference Include="SFA.DAS.Payments.Monitoring.Jobs.Client" Version="0.2.0-prerelease-957" />
     <PackageReference Include="SFA.DAS.Payments.ServiceFabric.Core" Version="2.0.3-prerelease-5" />
   </ItemGroup>

--- a/src/SFA.DAS.Payments.RequiredPayments.RequiredPaymentsService.Interfaces/SFA.DAS.Payments.RequiredPayments.RequiredPaymentsService.Interfaces.csproj
+++ b/src/SFA.DAS.Payments.RequiredPayments.RequiredPaymentsService.Interfaces/SFA.DAS.Payments.RequiredPayments.RequiredPaymentsService.Interfaces.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="Microsoft.ServiceFabric.Actors" Version="7.0.1001" />
     <PackageReference Include="Microsoft.ServiceFabric.Diagnostics.Internal" Version="7.0.1010" />
     <PackageReference Include="SFA.DAS.Payments.DataLocks.Messages" Version="0.1.137-prerelease-46" />
-    <PackageReference Include="SFA.DAS.Payments.EarningEvents.Messages" Version="2.0.0-prerelease-17" />
+    <PackageReference Include="SFA.DAS.Payments.EarningEvents.Messages" Version="0.1.130-prerelease-7" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/SFA.DAS.Payments.RequiredPayments.RequiredPaymentsService/SFA.DAS.Payments.RequiredPayments.RequiredPaymentsService.csproj
+++ b/src/SFA.DAS.Payments.RequiredPayments.RequiredPaymentsService/SFA.DAS.Payments.RequiredPayments.RequiredPaymentsService.csproj
@@ -20,6 +20,7 @@
     <PackageReference Include="Microsoft.ServiceFabric.Actors" Version="7.0.1001" />
     <PackageReference Include="Microsoft.ServiceFabric.Diagnostics.Internal" Version="7.0.1010" />
     <PackageReference Include="Microsoft.ServiceFabric.Data.Interfaces" Version="7.0.1010" />
+    <PackageReference Include="SFA.DAS.Payments.EarningEvents.Messages" Version="0.1.130-prerelease-7" />
     <PackageReference Include="SFA.DAS.Payments.ServiceFabric.Core" Version="2.0.3-prerelease-5" />
   </ItemGroup>
 


### PR DESCRIPTION
Updated employment check nuget package to pre-release version to consume ApprenticeshipIneligibleForFundingEarningEvent

Added handler for above event in RequiredPaymentsProxyService 

Updated RemovedLearnerService to consume ApprenticeshipIneligibleForFundingEarningEvent and identify RemovedLearningAims using RemovedLearnerAimIdentificationService